### PR TITLE
Fixed issue which caused error to be thrown when file content ended with...

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var detective = require('detective');
 var generator = require('inline-source-map');
 var combine = require('combine-source-map');
 
-var prepend = innersource(addRequire).replace(/\n/g, '');
-var postpend = innersource(addModule).replace(/\n/g, '');
+var prepend = innersource(addRequire).replace(/[\n\r]/g, '');
+var postpend = innersource(addModule).replace(/[\n\r]/g, '');
 
 module.exports = function(filename) {
   var buffer = '';


### PR DESCRIPTION
... a } and other similar characters like ) or ]...
The postpend string starts with a var declaration so for example if the postpend string got appended to code such as "var foo = function () { return 'foo'; }" you would get "var foo = function { return 'foo'; } var ..." Which throws an error - You need either a new line or a ; after the } for it to work. A new line might have messed up the source mapping so ; was the natural choice :)
