### PR TITLE
remove /index from module entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ function addModule(){
   if(typeof __filename !== 'undefined'){
     var moduleName = __filename.slice(0, __filename.lastIndexOf('.'));
     if (moduleName.match(/\/index$/)) {
-      moduleName = moduleName.slice(0, -6);
+      moduleName = (moduleName.length === 6)
+        ? '/' : moduleName.slice(0, -6);
     }
     global.require[moduleName] = module.exports;
   }


### PR DESCRIPTION
When I have directories like this

```
foo/
  index.js
bar/
  index.js
```

global.require table has `/foo/index` and `/bar/index`. node.js convention is to drop `/index`

Sorry about not updating tests, I'm fairly busy with another project and I'm fixing things as I find them.
